### PR TITLE
FIX: Typo en docs

### DIFF
--- a/02/reto2.md
+++ b/02/reto2.md
@@ -18,7 +18,7 @@
 | archiv4            | -rwxrw-r-- | **```$ chmod u=rwx,g=rw,o=r archiv4```**|
 | archiv5            | -rwxr----- | **```$ chmod u=rwx,g=r,o= archiv5```**|
 | archiv6            | -r-xrw-r-- | **```$ chmod u=rx,g=rw,o=r archiv6```**|
-| archiv7            | -r-------x | **```$ chmod u=r,g=,u=x archiv7```**|
+| archiv7            | -r-------x | **```$ chmod u=r,g=,o=x archiv7```**|
 | archiv8            | -rw-r--r-- | **```$ chmod u=rw,g=r,o=r archiv8```**|
 | archiv9            | -rw-rw-r-- | **```$ chmod u=rw,g=rw,o=r archiv9```**|
 


### PR DESCRIPTION
Hay un error en la documentación.
Corregí un comando mal escrito para el archiv7, debería ser o en lugar de u en el comando chmod

